### PR TITLE
added handling for states updated locally and remotely, cleanup

### DIFF
--- a/SwiftFlight.xcodeproj/project.pbxproj
+++ b/SwiftFlight.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		E2BE4C71254B532300F792A1 /* ConnectAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BE4C6F254B532300F792A1 /* ConnectAPI.swift */; };
 		E2BE4C72254B532300F792A1 /* UDPReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BE4C70254B532300F792A1 /* UDPReceiver.swift */; };
 		E2BE4C75254B832100F792A1 /* FlightControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BE4C74254B832100F792A1 /* FlightControls.swift */; };
+		E2DC08D0280F8AE100CE8094 /* TimedState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2DC08CF280F8AE000CE8094 /* TimedState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +24,7 @@
 		E2BE4C6F254B532300F792A1 /* ConnectAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectAPI.swift; sourceTree = "<group>"; };
 		E2BE4C70254B532300F792A1 /* UDPReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UDPReceiver.swift; sourceTree = "<group>"; };
 		E2BE4C74254B832100F792A1 /* FlightControls.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlightControls.swift; sourceTree = "<group>"; };
+		E2DC08CF280F8AE000CE8094 /* TimedState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimedState.swift; sourceTree = "<group>"; };
 		E5DFDB1DEF46816133EACCB5 /* libPods-SwiftFlight.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SwiftFlight.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -79,6 +81,7 @@
 				E2BE4C74254B832100F792A1 /* FlightControls.swift */,
 				E2BE4C6F254B532300F792A1 /* ConnectAPI.swift */,
 				E2BE4C70254B532300F792A1 /* UDPReceiver.swift */,
+				E2DC08CF280F8AE000CE8094 /* TimedState.swift */,
 				E2BE4C5B254B472F00F792A1 /* SwiftFlight.h */,
 				E2BE4C5C254B472F00F792A1 /* Info.plist */,
 			);
@@ -193,6 +196,7 @@
 				E2BE4C72254B532300F792A1 /* UDPReceiver.swift in Sources */,
 				E2BE4C71254B532300F792A1 /* ConnectAPI.swift in Sources */,
 				E2BE4C75254B832100F792A1 /* FlightControls.swift in Sources */,
+				E2DC08D0280F8AE100CE8094 /* TimedState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftFlight/ConnectAPI.swift
+++ b/SwiftFlight/ConnectAPI.swift
@@ -515,7 +515,6 @@ extension ConnectAPI: StreamDelegate {
         } else {
             
             guard let expectedCommandIndex: Int = requestedStates.firstIndex(where: { $0.id == commandID }) else {
-                print(commandID)
                 closeConnection()       // received an unrequested state
                 return
             }

--- a/SwiftFlight/ConnectAPI.swift
+++ b/SwiftFlight/ConnectAPI.swift
@@ -61,8 +61,10 @@ public class ConnectAPI: NSObject {
     public var StateInfoDict: Dictionary<String, StateInfo> = [:]
     public var States: [State] = []
     public var StateByID: Dictionary<Int32, State> = [:]
-//    public var cameraInfo: Dictionary<String, CameraInfo> = [:]
-//    public var cameraNameByNumber: Dictionary<Substring, String> = [:]
+    
+    private var requestedStates: [TimedState] = []  // queue, keeps track of when states are requested
+    private var updatedStates: Dictionary<Int32, Int> = [:]    // track when states are updated
+    // These let us discard outdated info later. We'll want to ignore any state info we've edited since requesting the info.
     
     let queue: DispatchQueue = DispatchQueue(label: "api-queue", qos: .userInteractive)
     
@@ -72,7 +74,10 @@ public class ConnectAPI: NSObject {
                 //don't get states from other aircraft
                 let pathArray = item.path?.split(separator: "/")
                 if !((pathArray?[0] == "aircraft") && ((pathArray?[1].count)! > 1)) {
-                    getState(ID: item.ID!)
+                    // don't get sounds
+                    if !(item.type == -1) {
+                        getState(ID: item.ID!)
+                    }
                 }
             }
         }
@@ -103,12 +108,18 @@ public class ConnectAPI: NSObject {
         status = ConnectionStates.Looking
     }
     
+    public func updateState(commandID: Int32, value: Any) {
+        StateByID[commandID]?.value = value
+        self.updatedStates[commandID] = Int(1000 * Date().timeIntervalSince1970)
+    }
+    
     public func setState(commandID: Int32, value: Bool) {
         queue.async {
             self.sendInt(val: commandID)
             self.sendBool(val: true)
             self.sendBool(val: value)
         }
+        updateState(commandID: commandID, value: value)
     }
     
     public func setState(commandID: Int32, value: Int32) {
@@ -117,6 +128,7 @@ public class ConnectAPI: NSObject {
             self.sendBool(val: true)
             self.sendInt(val: value)
         }
+        updateState(commandID: commandID, value: value)
     }
     
     public func setState(commandID: Int32, value: Float) {
@@ -125,6 +137,7 @@ public class ConnectAPI: NSObject {
             self.sendBool(val: true)
             self.sendFloat(val: value)
         }
+        updateState(commandID: commandID, value: value)
     }
     
     public func setState(commandID: Int32, value: String) {
@@ -133,6 +146,7 @@ public class ConnectAPI: NSObject {
             self.sendBool(val: true)
             self.sendString(val: value)
         }
+        updateState(commandID: commandID, value: value)
     }
     
     public func setState(commandID: Int32, value: Double) {
@@ -141,6 +155,7 @@ public class ConnectAPI: NSObject {
             self.sendBool(val: true)
             self.sendDouble(val: value)
         }
+        updateState(commandID: commandID, value: value)
     }
     
     public func setState(commandID: Int32, value: Int64) {
@@ -149,6 +164,7 @@ public class ConnectAPI: NSObject {
             self.sendBool(val: true)
             self.sendLong(val: value)
         }
+        updateState(commandID: commandID, value: value)
     }
     
     public func getState(ID: Int32) {
@@ -156,6 +172,7 @@ public class ConnectAPI: NSObject {
             self.sendInt(val: ID)
             self.sendBool(val: false)
         }
+        self.requestedStates.append(TimedState(id: ID))
     }
     
     public func sendCommand(commandID: Int32) {
@@ -424,6 +441,10 @@ public class ConnectAPI: NSObject {
         return -1
     }
     
+    public func getStateByString(str: String) {
+        getState(ID: getID(str: str))
+    }
+    
     public func getStateValue(str: String) -> Any? {
         if let id = StateInfoDict[str]?.ID {
             return StateByID[id]?.value ?? nil
@@ -450,6 +471,9 @@ public class ConnectAPI: NSObject {
             StateInfoDict.removeAll()
             States.removeAll()
             StateByID.removeAll()
+            
+            requestedStates.removeAll()
+            updatedStates.removeAll()
         }
     }
     
@@ -489,6 +513,20 @@ extension ConnectAPI: StreamDelegate {
         if commandID == -1 {
             readManifest(inputStream: inputStream)
         } else {
+            
+            guard let expectedCommandIndex: Int = requestedStates.firstIndex(where: { $0.id == commandID }) else {
+                print(commandID)
+                closeConnection()       // received an unrequested state
+                return
+            }
+            
+            let expectedCommand: TimedState = requestedStates[expectedCommandIndex]
+            requestedStates.remove(at: expectedCommandIndex)
+            
+            let hasBeenUpdated = updatedStates[commandID] ?? 0 >= (expectedCommand.time - 200)
+            // check if the value has been updated locally since requesting it, or within 200 ms
+            // before requesting. this allows Infinite Flight some time to process the update
+            
             let stateInfo = StateInfoByID[commandID]
             let state = StateByID[commandID]
             
@@ -497,32 +535,44 @@ extension ConnectAPI: StreamDelegate {
             if stateInfo?.type == 0 {    //bool
                 let value = readBoolean(inputStream: inputStream)
                 logger.debug("\(String(describing: stateInfo?.path)): \(value)")
-                state?.value = value as Bool
+                if !hasBeenUpdated {
+                    state?.value = value as Bool
+                }
                 
             } else if stateInfo?.type == 1 {    //int
                 let value = readInt(inputStream: inputStream)
                 logger.debug("\(String(describing: stateInfo?.path)): \(value)")
-                state?.value = value as Int32
+                if !hasBeenUpdated {
+                    state?.value = value as Int32
+                }
                 
             } else if stateInfo?.type == 2 {    //float
                 let value = readFloat(inputStream: inputStream)
                 logger.debug("\(String(describing: stateInfo?.path)): \(value)")
-                state?.value = value as Float
+                if !hasBeenUpdated {
+                    state?.value = value as Float
+                }
                 
             } else if stateInfo?.type == 3 {    //double
                 let value = readDouble(inputStream: inputStream)
                 logger.debug("\(String(describing: stateInfo?.path)): \(value)")
-                state?.value = value as Double
+                if !hasBeenUpdated {
+                    state?.value = value as Double
+                }
                 
             } else if stateInfo?.type == 4 {    //string
                 let value = readString(inputStream: inputStream)
                 logger.debug("\(String(describing: stateInfo?.path)): \(String(describing: value))")
-                state?.value = "\(value)"
+                if !hasBeenUpdated {
+                    state?.value = "\(value)"
+                }
                 
             } else if stateInfo?.type == 5 {    //long
                 let value = readLong(inputStream: inputStream)
                 logger.debug("\(String(describing: stateInfo?.path)): \(value)")
-                state?.value = value as Int64
+                if !hasBeenUpdated {
+                    state?.value = value as Int64
+                }
             } else if stateInfo?.type == -1 { //sound?
 //                let value = readString(inputStream: inputStream)
 //                if debug {
@@ -548,6 +598,10 @@ extension ConnectAPI: StreamDelegate {
             case 5: return "long"
             default: return "unknown"
         }
+    }
+    
+    private func timestampMilliseconds() -> Int {
+        return Int(1000 * Date().timeIntervalSince1970)
     }
     
 }

--- a/SwiftFlight/TimedState.swift
+++ b/SwiftFlight/TimedState.swift
@@ -1,0 +1,20 @@
+//
+//  TimedState.swift
+//  SwiftFlight
+//
+//  Created by Thomas Hogrefe on 3/28/22.
+//
+
+import Foundation
+
+class TimedState {
+    
+    public var id: Int32
+    public var time: Int
+    
+    init(id: Int32) {
+        self.id = id
+        self.time = Int(1000 * Date().timeIntervalSince1970)
+    }
+    
+}


### PR DESCRIPTION
States requested and updated are now stored with a timestamp. I've added logic to ensure SwiftFlight only holds the most-current information. If a state is requested, then updated locally before a response comes back, the response is discarded because there's newer local information. A new request will need to be made to check the status of the state on Infinite Flight.